### PR TITLE
Fix page bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>My Portfolio</title>
+    <title>Wesley Tao | Staff ML Scientist</title>
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900" rel="stylesheet">
@@ -38,10 +38,10 @@
                 <a href="#projects">Projects</a>
             </li>
             <li>
-              <a href ='#blog'>My Blog</a>
+                <a href="#skills">Skills</a>
             </li>
             <li>
-                <a href="#skills">Skills</a>
+                <a href="#blog">My Blog</a>
             </li>
             <li>
                 <a href="#contact">Contact</a>
@@ -165,7 +165,7 @@ oil commodity future trading strategy
                 <h4>Research Assistant</h4>
                 <p>
                   Completed independently a research project on electricity user's behavior study with Hausman-Taylor model and test effectiveness of the electricity pricing policy in Shanghai.</p>
-                    <p>Tested and proved the hypothesis that even at a low price difference +/- $0.03/kWh, people under the non-flat rate policy tend to use 12% less after 22:00 (peak hour) <p>
+                    <p>Tested and proved the hypothesis that even at a low price difference +/- $0.03/kWh, people under the non-flat rate policy tend to use 12% less after 22:00 (peak hour)</p>
                     <p>Used Hausman-Taylor model to exclude the unobserved individual effect and successfully measured price elasticities</p>
 
             </div>
@@ -229,11 +229,11 @@ oil commodity future trading strategy
                   </div>
                   <!-- End .project-image -->
                   <div class="project-info">
-                      <h3>Air Pollution in France z</h3>
+                      <h3>Air Pollution in France</h3>
                       <p>
                           Air pollution is causing 48000 French deaths per year. Over 47 million French people are exposed to a level of air pollution particles that are considered to be unsafe by the WHO.
                       </p>
-                      <a href="https://wesleytao.github.io/blog//2018/08/20/Pollution-in-France/">View Project</a>
+                      <a href="https://wesleytao.github.io/blog/2018/08/20/Pollution-in-France/">View Project</a>
                   </div>
                   <!-- End .project-info -->
               </div>
@@ -333,10 +333,10 @@ oil commodity future trading strategy
                     <a href="file/User Simulator Chatbot.pdf">Two types of User Simulator for Reinforcement-learning Chatbot</a>
                 </li>
                 <li>
-                    <a href="https://wesleytao.github.io/blog//2018/08/25/House-Price-Prediction/">House Price Prediction Data Challenges</a>
+                    <a href="https://wesleytao.github.io/blog/2018/08/25/House-Price-Prediction/">House Price Prediction Data Challenges</a>
                 </li>
                 <li>
-                    <a href="file/Early Expansion Phase of Delivery Company.pdf">Three strategic insights of early expansian phase of a delivery company</a>
+                    <a href="file/Early Expansion Phase of Delivery Company.pdf">Three strategic insights of early expansion phase of a delivery company</a>
                 </li>
 
 
@@ -370,7 +370,7 @@ oil commodity future trading strategy
             <div class="row">
                 <div class="col-sm-5 copyright">
                     <p>
-                        Copyright &copy; 2018 Wenyi Tao
+                        Copyright &copy; 2026 Wesley Tao
                     </p>
                 </div>
                 <div class="col-sm-2 top">
@@ -384,16 +384,7 @@ oil commodity future trading strategy
                             <a href="https://github.com/wesleytao" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a>
                         </li>
                         <li>
-                            <a href="https://stackoverflow.com/" target="_blank"><i class="fa fa-stack-overflow" aria-hidden="true"></i></a>
-                        </li>
-                        <li>
-                            <a href="https://www.facebook.com/" target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i></a>
-                        </li>
-                        <li>
-                            <a href="https://twitter.com/" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a>
-                        </li>
-                        <li>
-                            <a href="https://plus.google.com/" target="_blank"><i class="fa fa-google-plus" aria-hidden="true"></i></a>
+                            <a href="https://www.linkedin.com/in/wesleytao" target="_blank"><i class="fa fa-linkedin" aria-hidden="true"></i></a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
## Summary
- Page title: `"My Portfolio"` → `"Wesley Tao | Staff ML Scientist"`
- Nav order: align Skills before Blog to match page section order
- Project title: remove stray `z` from "Air Pollution in France"
- URLs: fix double slashes in two blog post links
- HTML: fix unclosed `<p>` tag in Research Assistant entry
- Typo: `expansian` → `expansion` in blog section
- Copyright: year `2018` → `2026`, name `Wenyi Tao` → `Wesley Tao`
- Footer socials: remove placeholder Stack Overflow/Facebook/Twitter/Google+ links; replace with LinkedIn (Google+ shut down 2019)

https://claude.ai/code/session_011SQdqvHb4FrcHyK7ArZmQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_011SQdqvHb4FrcHyK7ArZmQ5)_